### PR TITLE
fix comment style

### DIFF
--- a/CalcChannelMapping.m
+++ b/CalcChannelMapping.m
@@ -1,44 +1,44 @@
-%function Map = CalcChannelMapping(points1,points2)
+% function Map = CalcChannelMapping(points1,points2)
 %
-%Given a set of points in one channel and a matched set of points in the
-%other channel, calculated the matrix that maps one channel to the other.
-%IMPORTANT the input order matters because this will calculate the
-%transformation from points1 to points2!
+% Given a set of points in one channel and a matched set of points in the
+% other channel, calculated the matrix that maps one channel to the other.
+% IMPORTANT the input order matters because this will calculate the
+% transformation from points1 to points2!
 %
-%Inputs:
-%2xnumspots or numspotsx2 matrices of spots
-%NOTE this code forces points1 and points2 to end up as 2xnumspots
-%matrices, regardless of their sizes when entered as inputs.  Therefore to
-%use the outputted mapping, make sure that points1 and points2 are
-%2xnumspots!
+% Inputs:
+% 2xnumspots or numspotsx2 matrices of spots
+% NOTE this code forces points1 and points2 to end up as 2xnumspots
+% matrices, regardless of their sizes when entered as inputs.  Therefore to
+% use the outputted mapping, make sure that points1 and points2 are
+% 2xnumspots!
 %
-%Output:
-%A matrix A and a vector b, such that points2 = A*points1 + b
+% Output:
+% A matrix A and a vector b, such that points2 = A*points1 + b
 %
-%Algorithm:
-%We want points1 = A*points1 + b = points2
-%if we want to allow translations, reflection, rotation, scaling
-%Want to embed an affine transformation (Ax+b) in a linear space (Ax)
-%So define 
-%x = [points1;1]
-%M = [A, b; 0 1]
-%Then
-%M*x = [A*points1+b; 1] = y
-%Now, as with a linear transformation, find
-%argmin of M(||y - M*x||_2)^2
-%That is, minimize the error of our estimate of y = [points2;1] given an M
-%Use the normal equations as conditions of optimality:
-%(y-M*x)*x' = 0
-%Therefore
-%argmin of M = y*x'*(x*x')^(-1)
+% Algorithm:
+% We want points1 = A*points1 + b = points2
+% if we want to allow translations, reflection, rotation, scaling
+% Want to embed an affine transformation (Ax+b) in a linear space (Ax)
+% So define 
+% x = [points1;1]
+% M = [A, b; 0 1]
+% Then
+% M*x = [A*points1+b; 1] = y
+% Now, as with a linear transformation, find
+% argmin of M(||y - M*x||_2)^2
+% That is, minimize the error of our estimate of y = [points2;1] given an M
+% Use the normal equations as conditions of optimality:
+% (y-M*x)*x' = 0
+% Therefore
+% argmin of M = y*x'*(x*x')^(-1)
 %
-%Steph 9/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 9/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function [A,b] = CalcChannelMapping(points1,points2)
 
-%Make the inputs 2-by-numspots matrices, if they're not already, for
-%convenience
+% Make the inputs 2-by-numspots matrices, if they're not already, for
+% convenience
 if size(points1,1)~=2
     points1 = transpose(points1);
 end

--- a/CalcCombinedImage.m
+++ b/CalcCombinedImage.m
@@ -1,31 +1,31 @@
-%function composite = CalcCombinedImage(A,b,StartImg,EndImg,ShowResults)
+% function composite = CalcCombinedImage(A,b,StartImg,EndImg,ShowResults)
 %
-%Given two images and the transformation matrix and vectors A, b that 
-%define an affine map from StartImg to EndImg (see outputs of CalcChannelMapping), 
-%calculate the transformed version of StartImg and return a
-%composite of EndImg and the transformed image.
+% Given two images and the transformation matrix and vectors A, b that 
+% define an affine map from StartImg to EndImg (see outputs of CalcChannelMapping), 
+% calculate the transformed version of StartImg and return a
+% composite of EndImg and the transformed image.
 %
-%This is called by smFRET so that you can find spots in a composite image
-%from both channels, the idea being that medium-FRET spots will have
-%decreased intensities in the two channels and may be missed by a
-%spotfinding algorithm that only looks for spots in green and spots in red
-%separately.
+% This is called by smFRET so that you can find spots in a composite image
+% from both channels, the idea being that medium-FRET spots will have
+% decreased intensities in the two channels and may be missed by a
+% spotfinding algorithm that only looks for spots in green and spots in red
+% separately.
 %
-%Note: you could also modify this code to find tform using built-in Matlab
-%functions:
+% Note: you could also modify this code to find tform using built-in Matlab
+% functions:
 %   Use fitgeotrans with pairs of matching points:
 %   tform = fitgeotrans(matchRall',matchGall','Affine');
 %   where matchRall, matchRall are, for example, the pairs of points found
 %   in smFRET from bead images. Or, use the Matlab function
 %   cpselect to generate points manually.
 %
-%Update 1/2014: fitgeotrans does a bit better than my handwritten code in
-%CalcChannelMapping; it might be iterating to find optimal solutions or
-%something like that.  Regardless, I now use fitgeotrans, but, for
-%backwards compatibility, turn the output of fitgeotrans into A, b, and
-%then re-form tform here.  
+% Update 1/2014: fitgeotrans does a bit better than my handwritten code in
+% CalcChannelMapping; it might be iterating to find optimal solutions or
+% something like that.  Regardless, I now use fitgeotrans, but, for
+% backwards compatibility, turn the output of fitgeotrans into A, b, and
+% then re-form tform here.  
 %
-%Copyright 2014 Stephanie Johnson, University of California, San Francisco
+% Copyright 2014 Stephanie Johnson, University of California, San Francisco
 
 function composite = CalcCombinedImage(A,b,StartImg,EndImg,ShowResults)
 

--- a/CalcSpotIntensityV2.m
+++ b/CalcSpotIntensityV2.m
@@ -1,26 +1,26 @@
-%function I = CalcSpotIntensityV2(img,spotcen)
+% function I = CalcSpotIntensityV2(img,spotcen)
 %
-%This version uses a circular area to define a spot, rather than a
-%square.  The size of the circle is hard-coded in right now.  You cannot
-%pass this function a spot that is right at the edge of the image!--needs
-%to be more than SpotDiam/2 = 2 pxls from the edges of the image.
+% This version uses a circular area to define a spot, rather than a
+% square.  The size of the circle is hard-coded in right now.  You cannot
+% pass this function a spot that is right at the edge of the image!--needs
+% to be more than SpotDiam/2 = 2 pxls from the edges of the image.
 %
-%Given a movie and a spot center, returns the sum of the intensities in a 
-%circle around the spot center for each frame in the movie.
+% Given a movie and a spot center, returns the sum of the intensities in a 
+% circle around the spot center for each frame in the movie.
 %
-%My spot finding function (and all related functions that manipulate found
-%spots) returns spots in the coordinate system of the matrix, that is, with
-%the spot center given as (row;col), though row and col don't have to be integers.  
+% My spot finding function (and all related functions that manipulate found
+% spots) returns spots in the coordinate system of the matrix, that is, with
+% the spot center given as (row;col), though row and col don't have to be integers.  
 %
-%Steph 10/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 10/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function I = CalcSpotIntensityV2(img,spotcen)
 
-%The way I'm going to define a circle, or really a disk, that contains the
-%spot is by creating a square mask where some elements are zero, and
-%multiplying that by the image.  DNAs in our hands are about 3x3 pixels, so
-%doing a 5 pxl diameter circle around each spot. (4 is hard.)
+% The way I'm going to define a circle, or really a disk, that contains the
+% spot is by creating a square mask where some elements are zero, and
+% multiplying that by the image.  DNAs in our hands are about 3x3 pixels, so
+% doing a 5 pxl diameter circle around each spot. (4 is hard.)
 
 SpotDiam = 5;
 
@@ -28,12 +28,12 @@ mask = zeros(SpotDiam,SpotDiam,class(img));
 mask(2:4,:) = ones(3,SpotDiam,class(img));
 mask(:,2:4) = ones(SpotDiam,3,class(img));
 
-%The part of the image that contains the spot is going to be in:
+% The part of the image that contains the spot is going to be in:
 SpotCenRound = round(spotcen);
 SpotBox = [SpotCenRound(1)-floor(SpotDiam/2), SpotCenRound(1)+floor(SpotDiam/2);...
     SpotCenRound(2)-floor(SpotDiam/2), SpotCenRound(2)+floor(SpotDiam/2)];
 
-%Make sure the spot isn't too close to the edge of the image: 
+% Make sure the spot isn't too close to the edge of the image: 
 if SpotBox(1,1)<=0 || SpotBox(1,2)>size(img,1) || ...
         SpotBox(2,1)<=0 || SpotBox(2,2)>size(img,2)
     disp(strcat('Spot must be further than: ',int2str(SpotDiam/2),' pxls from edge of img'))

--- a/ExamineChannelMap.m
+++ b/ExamineChannelMap.m
@@ -1,25 +1,25 @@
-%Make a grid the size of one of the channels:
+% Make a grid the size of one of the channels:
 meshspace = 20;
 x = 1:meshspace:512/2;
 y = ones(length(x),1)*[1:meshspace:512];
-%Turn the x,y coordinates of this mesh into a 2xnumpoints matrix that can
-%be multiplied by a channel map:
+% Turn the x,y coordinates of this mesh into a 2xnumpoints matrix that can
+% be multiplied by a channel map:
 points(1,:) = repmat(x,1,size(y,1)*size(y,2)/length(x));
 points(2,:) = reshape(y,1,size(y,1)*size(y,2));
 
-%Plot the starting mesh to check:
+% Plot the starting mesh to check:
 % figure('Position',[200 200 325 625])
 % %plot(x,y,'.b')
 % plot(points(1,:),points(2,:),'.b')
 % xlim([-10 512/2+10])
 % ylim([-10 512+10])
 
-%Create the transformed mesh from my map (load a ChannelMapping.mat file
-%first)
+% Create the transformed mesh from my map (load a ChannelMapping.mat file
+% first)
 newSteph = A*points+repmat(b,1,size(points,2));
 newMatlab = Amatlab*points+repmat(bmatlab,1,size(points,2));
 
-%Plot and compare
+% Plot and compare
 figure('Position',[200 200 325 625])
 plot([newMatlab(1,:);points(1,:)],[newMatlab(2,:);points(2,:)],'-b')
 hold on

--- a/FindSpotDists.m
+++ b/FindSpotDists.m
@@ -1,21 +1,21 @@
-%function Dists = FindSpotDists(spots1,spots2)
+% function Dists = FindSpotDists(spots1,spots2)
 %
-%Find the pairwise distances between all the spots in spots1 and all
-%the spots in spots2 (or spots1 with itself, if no spots2 is passed). Spots
-%1 and spots2 must be (x,y) pairs of positions along either the rows or the columns.
+% Find the pairwise distances between all the spots in spots1 and all
+% the spots in spots2 (or spots1 with itself, if no spots2 is passed). Spots
+% 1 and spots2 must be (x,y) pairs of positions along either the rows or the columns.
 %
-%Returns a matrix of distances of size length(spots1) by length(spots2),
-%where each row is the distance from each spot in spots1 to each spot in
-%spots2.
+% Returns a matrix of distances of size length(spots1) by length(spots2),
+% where each row is the distance from each spot in spots1 to each spot in
+% spots2.
 %
-%Steph 8/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 8/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function Dists = FindSpotDists(spots1,spots2)
 
 if ~exist('spots2','var') spots2 = spots1; end
 
-%Make the inputs 2-by-numspots matrices, if they're not already:
+% Make the inputs 2-by-numspots matrices, if they're not already:
 if size(spots1,1)~=2
     spots1 = transpose(spots1);
 end
@@ -25,7 +25,7 @@ end
 
 Dists = zeros(size(spots1,2),size(spots2,2));
 
-%There are two ways to find the distances.  Here's the simplest but slower way:
+% There are two ways to find the distances.  Here's the simplest but slower way:
 % for i = 1:size(spots1,2)
 %     for j = 1:size(spots2,2)
 %         %Dists(i,j) = sqrt((spots1(1,i)-spots2(1,j))^2 + (spots1(2,i)-spots2(2,j))^2);
@@ -34,23 +34,23 @@ Dists = zeros(size(spots1,2),size(spots2,2));
 %     end
 % end
 
-%Smarter way: (Thanks to Matt Johnson for this derivation and code!)
-%Consider two spots vec(a) = spots1(:,i) and vec(b) = spots2(:,j).  We want
-%norm(vec(a)-vec(b)). Note
-%norm(vec(a)-vec(b))^2 = <vec(a)-vec(b),vec(a)-vec(b)>
+% Smarter way: (Thanks to Matt Johnson for this derivation and code!)
+% Consider two spots vec(a) = spots1(:,i) and vec(b) = spots2(:,j).  We want
+% norm(vec(a)-vec(b)). Note
+% norm(vec(a)-vec(b))^2 = <vec(a)-vec(b),vec(a)-vec(b)>
 %                      = norm(vec(a))^2+norm(vec(b))^2 - 2<vec(a),vec(b)>
 %                      = norm(vec(a))^2+norm(vec(b))^2 - 2*(transpose(spots1)*spots2)(i,j)
-%Instead of having a double for-loop, you do this in one line as a matrix
-%operation, using matlab's bsxfun to take care of the fact that spots1 and
-%spots2 aren't necessarily the same size, and that transpose(spots1)*spots2
-%isn't the same size as spots1 and spots2
+% Instead of having a double for-loop, you do this in one line as a matrix
+% operation, using matlab's bsxfun to take care of the fact that spots1 and
+% spots2 aren't necessarily the same size, and that transpose(spots1)*spots2
+% isn't the same size as spots1 and spots2
 
 Dists = sqrt(bsxfun(@plus,sum(spots1.^2,1)',sum(spots2.^2,1))-2*spots1'*spots2);
-%What the above line does:
-%sum(spots1.^2,1)' will be a size(spots1,2) column that contains the norm^2
+% What the above line does:
+% sum(spots1.^2,1)' will be a size(spots1,2) column that contains the norm^2
 %   of each column of spots1
-%sum(spots2.^2,1) will be a size(spots2,2) row that contains the norm^2 of
+% sum(spots2.^2,1) will be a size(spots2,2) row that contains the norm^2 of
 %   each column of spots2
-%bsxfun(@plus,sum(spots1.^2,1)',sum(spots2.^2,1)) will be a size(spots1,2)
+% bsxfun(@plus,sum(spots1.^2,1)',sum(spots2.^2,1)) will be a size(spots1,2)
 %   by size(spots2,2) matrix where each element (i,j) is
 %   norm(spots1(:,i))^2+norm(spots2(:,j))^2

--- a/FindSpotIntensities.m
+++ b/FindSpotIntensities.m
@@ -1,10 +1,10 @@
-%function SpotIntensities = FindSpotIntensities(spots)
+% function SpotIntensities = FindSpotIntensities(spots)
 %
-%Takes as its input the cell array of ROIs that's the output of
-%FindSpotsV2, and finds the total intensity in each ROI, and returns those
-%intensities in a vector of length length(spots).
+% Takes as its input the cell array of ROIs that's the output of
+% FindSpotsV2, and finds the total intensity in each ROI, and returns those
+% intensities in a vector of length length(spots).
 %
-%Steph 6/2013
+% Steph 6/2013
 
 function SpotIntensities = FindSpotIntensities(spots)
 
@@ -14,5 +14,5 @@ for i = 1:length(spots)
     SpotIntensities(i) = sum(sum(spots{i}));
 end
 
-%That almost wasn't worth a separate function ... maybe I'll turn this into
-%a function that also plots traces or something ... 
+% That almost wasn't worth a separate function ... maybe I'll turn this into
+% a function that also plots traces or something ... 

--- a/FindSpotMatches.m
+++ b/FindSpotMatches.m
@@ -1,29 +1,29 @@
-%function [matched1,matched2] = FindSpotMatches(spots1,spots2)
+% function [matched1,matched2] = FindSpotMatches(spots1,spots2)
 %
-%Given two sets of spots (e.g., a set of spots found in the red channel and
-%a set of spots in the green channel), find a matching between them.
-%IMPORTANT: it will match the spots in spots1 to spots in spots2, so the
-%order you enter the inputs in matters!
+% Given two sets of spots (e.g., a set of spots found in the red channel and
+% a set of spots in the green channel), find a matching between them.
+% IMPORTANT: it will match the spots in spots1 to spots in spots2, so the
+% order you enter the inputs in matters!
 %
-%Inputs are (x,y) pairs along the rows or columns for two sets of spots.
-%Returns two sets of spots, where each column of matched1 and matched 2 is
-%(x,y) of a spot, and the first column of matched1 is the spot that matches
-%the spot represented by the first column of matched 2, etc.
+% Inputs are (x,y) pairs along the rows or columns for two sets of spots.
+% Returns two sets of spots, where each column of matched1 and matched 2 is
+% (x,y) of a spot, and the first column of matched1 is the spot that matches
+% the spot represented by the first column of matched 2, etc.
 %
-%Currently implemented with a "greedy" algorithm, which assumes the
-%alignment between the spots (ie. the channels) isn't too far off to begin
-%with.  So just find the spot in the other channel with the shortest
-%distance to the current spot.
+% Currently implemented with a "greedy" algorithm, which assumes the
+% alignment between the spots (ie. the channels) isn't too far off to begin
+% with.  So just find the spot in the other channel with the shortest
+% distance to the current spot.
 %
-%Steph 9/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 9/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function [matched1,matched2] = FindSpotMatches(spots1,spots2)
 
-%global TotImg
+% global TotImg
 
-%Make the inputs 2-by-numspots matrices, if they're not already, for
-%convenience
+% Make the inputs 2-by-numspots matrices, if they're not already, for
+% convenience
 if size(spots1,1)~=2
     spots1 = transpose(spots1);
 end
@@ -31,13 +31,13 @@ if size(spots2,1)~=2
     spots2 = transpose(spots2);
 end
 
-%Get the distances between all the spots:
+% Get the distances between all the spots:
 Dists = FindSpotDists(spots1,spots2);
 
 [minDists,ind] = min(Dists,[],2); %Minimum along each row
-%Assume that if a spot in spots1 doesn't have match that's a shorter
-%distance away than the mean distance over all the spots plus the standard
-%deviation, that that spot doesn't have a match:
+% Assume that if a spot in spots1 doesn't have match that's a shorter
+% distance away than the mean distance over all the spots plus the standard
+% deviation, that that spot doesn't have a match:
 maxDist = mean(minDists)+std(minDists,1);
 
 matched1 = [];

--- a/FindSpotsV5.m
+++ b/FindSpotsV5.m
@@ -1,58 +1,58 @@
-%function [spots,n,xout] = FindSpotsV5(img,varargin)
+% function [spots,n,xout] = FindSpotsV5(img,varargin)
 %
-%Given an image (ie. a matrix of intensity values), find the centers of all 
-%the spots. Also accepts a movie, in which case it will analyze the first ten frames.
+% Given an image (ie. a matrix of intensity values), find the centers of all 
+% the spots. Also accepts a movie, in which case it will analyze the first ten frames.
 %
-%Does some spot screening: spots can't be too close to another spot or to
-%the edge, where "too close" is defined by maxsize.
+% Does some spot screening: spots can't be too close to another spot or to
+% the edge, where "too close" is defined by maxsize.
 %
-%V5, compared to V3, lets spots be closer together (or further apart) than
-%the scale defined by neighborhoods for ordfilt2.
+% V5, compared to V3, lets spots be closer together (or further apart) than
+% the scale defined by neighborhoods for ordfilt2.
 %
-%Inputs:
-%img: image (matrix of pixel intensities: x-by-y pixels, or x by y by time, 
+% Inputs:
+% img: image (matrix of pixel intensities: x-by-y pixels, or x by y by time, 
 %   where time is in the third dimension)
 %
-%Optional inputs: These must be entered in pairs:
-%<parameter_name1>,<value1>,<parameter_name2>,<value2>, ...
+% Optional inputs: These must be entered in pairs:
+% <parameter_name1>,<value1>,<parameter_name2>,<value2>, ...
 %
-%'maxsize',<val>: Spots will be excluded if they are closer than maxsize.
-%'NeighborhoodSize',<val>: A little bigger than the size we expect spots to be 
+% 'maxsize',<val>: Spots will be excluded if they are closer than maxsize.
+% 'NeighborhoodSize',<val>: A little bigger than the size we expect spots to be 
 %   (area); for ordfilt2. Neighborhood in which to look for local maxima and
 %   minima. Needs to be a perfect square.  Best if sqrt(maxsize) is odd.  Default is 9^2.
-%'ShowResults',1: to show an image at the end with boxes 
+% 'ShowResults',1: to show an image at the end with boxes 
 %   around all the spots (you can also use ScreenSpots for this, which has
 %   an interactive component).
-%'UseCentroid',1: take the centroid instead of the max pixel
+% 'UseCentroid',1: take the centroid instead of the max pixel
 %   value to find the spot center.  Currently centroid
 %   actually does a worse job, at least for bead maps.
-%'UserThresh',<val>: Instead of calculating a threshold for "true" maxima
+% 'UserThresh',<val>: Instead of calculating a threshold for "true" maxima
 %   automatically, will use val.
-%'ImgTitle',<string>: If ShowResults is 1 and you want to give the image a title
+% 'ImgTitle',<string>: If ShowResults is 1 and you want to give the image a title
 %   (e.g., 'Green' so you know it's the green channel currently being analyzed).
 %   Default is 'Spots'.
 %
-%Outputs:
-%Spots:  a 2-by-numspots vector where each column is the (row,col) for the center of
+% Outputs:
+% Spots:  a 2-by-numspots vector where each column is the (row,col) for the center of
 %   each spot found in terms of the matrix of intensities that makes the
 %   image.  Note row and col don't need to be integers here--but I'm keeping
 %   the output in terms of the coordinate system of the matrix, not normal
 %   Cartesian (x,y) coordinates.
-%n,xout: outputs of the histogram of "diffs", in case the user wants to
+% n,xout: outputs of the histogram of "diffs", in case the user wants to
 %   choose a better threshold for true maxima
 %
-%Algorithm for finding spots:
-%(1) Identify pixels that are their maxes or mins in a local
-%neighborhood.
-%(2) Identify as true local maxes those maxes that are significantly bigger
-%than the surrounding minima.
-%(3) Do some light screening of spots: don't include any too close to the
+% Algorithm for finding spots:
+% (1) Identify pixels that are their maxes or mins in a local
+% neighborhood.
+% (2) Identify as true local maxes those maxes that are significantly bigger
+% than the surrounding minima.
+% (3) Do some light screening of spots: don't include any too close to the
 %   edges of the image.
-%(4) Return either the position of the max intensity or the centroid around
+% (4) Return either the position of the max intensity or the centroid around
 %   each true maximum as a spot.
 %
-%Steph 8/2013, updated 10/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 8/2013, updated 10/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function [spots,n,xout] = FindSpotsV5(img,varargin)
 
@@ -60,7 +60,7 @@ function [spots,n,xout] = FindSpotsV5(img,varargin)
 %%%%Likelihood estimation for better threshold detection
 %%%%Figure out centroid thing
 
-%Defaults for optional inputs:
+% Defaults for optional inputs:
 NeighborhoodSize = 9^2;
 maxsize = 6;
 ShowResults = 0;
@@ -69,11 +69,11 @@ UserThresh = 0;
 boxsize = maxsize;
 ImgTitle = 'Spots';
 
-%Other defaults:
+% Other defaults:
 cen_boxsize = 2;%Size of the box to use for centroid calculation will be cen_boxsize*2+1
 mov_fr = 10; %Number of frames to average over, if given a movie 
 
-%Optional inputs:
+% Optional inputs:
 if ~isempty(varargin)
     for i=1:2:length(varargin)
         if strcmpi(varargin{i},'ShowResults')
@@ -94,7 +94,7 @@ if ~isempty(varargin)
     end
 end
 
-%Error handling for inputs:
+% Error handling for inputs:
 if rem(NeighborhoodSize,sqrt(NeighborhoodSize))~=0
     disp('Spot finding: NeighborhoodSize must be a perfect square.')
     spots = -1;
@@ -103,7 +103,7 @@ if rem(NeighborhoodSize,sqrt(NeighborhoodSize))~=0
     return
 end
 
-%Make sure the image is properly scaled, and average if given a movie:
+% Make sure the image is properly scaled, and average if given a movie:
 if size(img,3)==1
     imggray = mat2gray(img);
     mov = 0;
@@ -115,24 +115,24 @@ else
     mov = 1;
 end
 
-%May need to do some background subtraction and/or smoothing here, or maybe
-%only for the non-movie inputs
+% May need to do some background subtraction and/or smoothing here, or maybe
+% only for the non-movie inputs
 
-%(1) Define a neighborhood as NeighborhoodSize square pixels--want the max and min
-%calculations to be over areas roughly the size we expect beads to be
+% (1) Define a neighborhood as NeighborhoodSize square pixels--want the max and min
+% calculations to be over areas roughly the size we expect beads to be
 maxes = ordfilt2(imggray,NeighborhoodSize,ones(sqrt(NeighborhoodSize),sqrt(NeighborhoodSize))); 
     %Note about ordfilt: This tests over square neighborhoods; make a matrix that's not ones
     %everywhere to look over some other kind of domain shape.
 mins  = ordfilt2(imggray,1,ones(sqrt(NeighborhoodSize),sqrt(NeighborhoodSize)));
 
-%(2) Identify true maxes.  
-%Need to define a threshold for true maxes.
-%If we histogram diffs, we'll see two peaks, one for true maxes, one for
-%background.  Best way to pick a threshold is to use a likelihood ratio test
-%to pick where the diffs are most likely to be part of the true maxes peak
-%and unlikely to be part of the background peak.  For now, just picking the
-%mean value between the centerpoints of two gaussians fit to a histogram of
-%the diffs (doesn't work great but works ok mostly)
+% (2) Identify true maxes.  
+% Need to define a threshold for true maxes.
+% If we histogram diffs, we'll see two peaks, one for true maxes, one for
+% background.  Best way to pick a threshold is to use a likelihood ratio test
+% to pick where the diffs are most likely to be part of the true maxes peak
+% and unlikely to be part of the background peak.  For now, just picking the
+% mean value between the centerpoints of two gaussians fit to a histogram of
+% the diffs (doesn't work great but works ok mostly)
 diffs = maxes-mins;
 [n,xout] = hist(reshape(diffs,1,numel(diffs)),50);
 if ~UserThresh
@@ -149,28 +149,28 @@ if ~UserThresh
     end
 end
 truemaxes = (maxes-mins) > truemaxthresh;
-%Finally find where the value of the image equals the local max, and keep
-%this local max only if truemax for that pixel is 1:
+% Finally find where the value of the image equals the local max, and keep
+% this local max only if truemax for that pixel is 1:
 temppeaks = find((imggray==maxes).*truemaxes);
-%Find uses linear indexing (which is done column-wise), so convert these to (row,col):
+% Find uses linear indexing (which is done column-wise), so convert these to (row,col):
 [peaks_i,peaks_j] = ind2sub(size(imggray),temppeaks);
 peaks = [peaks_i,peaks_j];
 
 disp(strcat('Number of peaks found: ',int2str(size(peaks,1))))
 
-%For deciding if spots are too close together: first need to find all the
-%distances between spots:
+% For deciding if spots are too close together: first need to find all the
+% distances between spots:
 Dists = FindSpotDists(peaks);
-%Declare that spots can't have centers closer than maxsize:
+% Declare that spots can't have centers closer than maxsize:
 spottooclose = Dists>maxsize;
-%Each row will be all 1's if the spot represented by the row is more than
-%maxsize away from another spot.  If there's another spot too
-%close, one or more elements will be zero.  So below, ask if the sum of a
-%peak's row is equal to the length of the row (minus one, because of the
-%zero element where it's too close to itself)
+% Each row will be all 1's if the spot represented by the row is more than
+% maxsize away from another spot.  If there's another spot too
+% close, one or more elements will be zero.  So below, ask if the sum of a
+% peak's row is equal to the length of the row (minus one, because of the
+% zero element where it's too close to itself)
 
-%Exclude any peaks that are too close to the boundaries or to another spot, 
-%and calculate centroid if user desires:
+% Exclude any peaks that are too close to the boundaries or to another spot, 
+% and calculate centroid if user desires:
 spots = [];
 for i = 1:size(peaks,1)
     if (peaks(i,1)-maxsize)>=1 && (peaks(i,1)+maxsize)<=size(imggray,1) && ...
@@ -193,9 +193,9 @@ end
 
 disp(strcat('Number of peaks kept: ',int2str(size(spots,1))))
 
-%For checking the results: make a figure that puts a box around each spot
-%found.  Also put a red x where it thinks the center of each spot is.
-%Updated 1/2014 for some error handling in case no spots were found:
+% For checking the results: make a figure that puts a box around each spot
+% found.  Also put a red x where it thinks the center of each spot is.
+% Updated 1/2014 for some error handling in case no spots were found:
 if ShowResults && size(spots,1) > 0 && size(spots,2) > 0
     PutBoxesOnImageV4(imggray,spots,boxsize,0);
     title(ImgTitle,'Fontsize',16)

--- a/GetInfoFromMetaData.m
+++ b/GetInfoFromMetaData.m
@@ -1,11 +1,11 @@
-%function val = GetInfoFromMetaData(dirname,paramname)
+% function val = GetInfoFromMetaData(dirname,paramname)
 %
-%Paramname can be: 
-%imgsize ->output will be a vector of xpxls,ypxls
-%fps -> output will be frames per second
+% Paramname can be: 
+% imgsize ->output will be a vector of xpxls,ypxls
+% fps -> output will be frames per second
 %
-%Steph 10/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 10/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function val = GetInfoFromMetaData(dirname,paramname)
 

--- a/LoadUManagerTifsV5.m
+++ b/LoadUManagerTifsV5.m
@@ -1,16 +1,16 @@
-%function allimgs = LoadUManagerTifsV5(D)
+% function allimgs = LoadUManagerTifsV5(D)
 %
-%Loads all the images in a uManager-created folder into one 3-d matrix.
-%D is the full path to the folder where they're stored; output is the
-%image matrix.  In V5, images returned are NOT scaled between 0 and 1.
-%Also, the optional input allows the user to specify how many images to
-%load, in the form of [start end] vector.
+% Loads all the images in a uManager-created folder into one 3-d matrix.
+% D is the full path to the folder where they're stored; output is the
+% image matrix.  In V5, images returned are NOT scaled between 0 and 1.
+% Also, the optional input allows the user to specify how many images to
+% load, in the form of [start end] vector.
 %
-%Updated 1/2014 to return an allimgs array of the same integer type as 
-%the original file (in our case, to keep it as uint16).
+% Updated 1/2014 to return an allimgs array of the same integer type as 
+% the original file (in our case, to keep it as uint16).
 %
-%Steph 3/2013, updated 10/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 3/2013, updated 10/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function allimgs = LoadUManagerTifsV5(D,varargin)
 

--- a/PutBoxesOnImageV4.m
+++ b/PutBoxesOnImageV4.m
@@ -1,23 +1,23 @@
-%function PutBoxesOnImageV4(img,spots,boxdim,boxcolor)
+% function PutBoxesOnImageV4(img,spots,boxdim,boxcolor)
 %
-%Same as PutBoxesOnImageV3, but puts circles on the image instead of boxes.
-%Boxdim is the DIAMETER of the circle.
+% Same as PutBoxesOnImageV3, but puts circles on the image instead of boxes.
+% Boxdim is the DIAMETER of the circle.
 %
-%Given a matrix of pixel intensities (ie. an image) and spot centers (in terms
-%of the matrix coordinates--that is, (row,col) for spot centers), and a circle 
-%dimension (diameter), put circles on top of the image 
-%that bound the spots, and an x where it thinks the center is.  Note that 
-%spots doesn't have to contain integers.
+% Given a matrix of pixel intensities (ie. an image) and spot centers (in terms
+% of the matrix coordinates--that is, (row,col) for spot centers), and a circle 
+% dimension (diameter), put circles on top of the image 
+% that bound the spots, and an x where it thinks the center is.  Note that 
+% spots doesn't have to contain integers.
 %
-%Combines plot and imshow, so the centers can show up as
-%non-integer pixels (V2 rounds to the nearest pixel).
+% Combines plot and imshow, so the centers can show up as
+% non-integer pixels (V2 rounds to the nearest pixel).
 %
-%Steph 10/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 10/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function PutBoxesOnImageV4(img,spots,boxdim,NoX,boxcolor)
 
-%Decided not to force the image to be scaled
+% Decided not to force the image to be scaled
 % if min(img(:))~=0 || max(img(:))~= 1
 %     img = mat2gray(img);
 % end
@@ -25,7 +25,7 @@ function PutBoxesOnImageV4(img,spots,boxdim,NoX,boxcolor)
 if ~exist('NoX','var') NoX = 0; end
 if ~exist('boxcolor','var') boxcolor = 'g'; end
 
-%Make sure the spots are listed as one spot per row:
+% Make sure the spots are listed as one spot per row:
 if size(spots,2)~=2
     spots = transpose(spots);
 end
@@ -40,8 +40,8 @@ for j = 1:length(spots)
     plot(spots(j,2)+boxdim/2*cos(t),spots(j,1)+boxdim/2*sin(t),strcat('-',boxcolor))
 end
 
-%Lastly add a red dot in the center:
-%Update 9/2013: a red dot instead of an x
+% Lastly add a red dot in the center:
+% Update 9/2013: a red dot instead of an x
 if ~NoX
     %plot(spots(:,2),spots(:,1),'xr')
     plot(spots(:,2),spots(:,1),'.r','MarkerSize',3)

--- a/ScreenSpotsV2.m
+++ b/ScreenSpotsV2.m
@@ -1,21 +1,21 @@
-%function newspots = ScreenSpots(img,spotcenters,boxdim,varargin)
+% function newspots = ScreenSpots(img,spotcenters,boxdim,varargin)
 %
-%Interactive function that allows user to choose spots, from those found by 
-%FindSpotsV3, that they don't want included in further analyses.
+% Interactive function that allows user to choose spots, from those found by 
+% FindSpotsV3, that they don't want included in further analyses.
 %
-%Inputs are the image that spots were found in, a vector of (x,y)
-%coordinates where the spot centers are, and boxdim that determines the
-%size of the box to put around each spot.  The user should click in the box
-%in order to deselect or re-select a spot.  Output is a vector of the kept
-%spotcenters.
+% Inputs are the image that spots were found in, a vector of (x,y)
+% coordinates where the spot centers are, and boxdim that determines the
+% size of the box to put around each spot.  The user should click in the box
+% in order to deselect or re-select a spot.  Output is a vector of the kept
+% spotcenters.
 %
-%Optional input is a string to put on the image, so you know what you're
-%analyzing.
+% Optional input is a string to put on the image, so you know what you're
+% analyzing.
 %
-%This version uses an updated version of PutBoxesOnImage that allows figure
-%data to be replaced without replotting the whole thing--makes it much faster!
+% This version uses an updated version of PutBoxesOnImage that allows figure
+% data to be replaced without replotting the whole thing--makes it much faster!
 %
-%Steph 6/2013
+% Steph 6/2013
 
 function newspots = ScreenSpotsV2(img,spotcenters,boxdim,varargin)
 

--- a/UserSpotSelectionV4.m
+++ b/UserSpotSelectionV4.m
@@ -1,28 +1,28 @@
-%function UserSpotSelectionV4()
+% function UserSpotSelectionV4()
 %
-%Iterates through all the spots in a movie and allows user to adjust
-%background, keep the ones they like, etc. Note that spots are passed in in
-%the frame of reference of the ACCEPTOR channel.
+% Iterates through all the spots in a movie and allows user to adjust
+% background, keep the ones they like, etc. Note that spots are passed in in
+% the frame of reference of the ACCEPTOR channel.
 %
-%The CPLC FRET code (in IDL) from TJ Ha's lab at UIUC uses a circle that's
-%9 pxls diameter, and includes 3 pixels in the first row, then 5 pixels, 
-%7 pxls, 9, 9, 9, 7, 5, 3.
+% The CPLC FRET code (in IDL) from TJ Ha's lab at UIUC uses a circle that's
+% 9 pxls diameter, and includes 3 pixels in the first row, then 5 pixels, 
+% 7 pxls, 9, 9, 9, 7, 5, 3.
 %
-%V3 uses circles instead of squares for calculating intensities.
-%V4 isn't passed a movie; instead it's passed a directory name, and
-%only loads 100 frames at a time, calculates the intensity, then loads the
-%next 100 frames etc.  Otherwise my computer runs out of RAM.
+% V3 uses circles instead of squares for calculating intensities.
+% V4 isn't passed a movie; instead it's passed a directory name, and
+% only loads 100 frames at a time, calculates the intensity, then loads the
+% next 100 frames etc.  Otherwise my computer runs out of RAM.
 %
-%Updated 12/2013 to allow the user to pass the figure position information
-%via params, so it's easier to put this code onto different computers.
+% Updated 12/2013 to allow the user to pass the figure position information
+% via params, so it's easier to put this code onto different computers.
 %
-%Steph 10/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 10/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function UserSpotSelectionV4(spots,PathToMovie,params,A,b,savedir,fps,setnum)
 
 %%%Setting up some stuff
-%Subfunction: Getting red and green channels out of a combined image:
+% Subfunction: Getting red and green channels out of a combined image:
     function [imgRed,imgGreen] = SplitImg(img,params_struct)
         if params_struct.splitx
                 if ~params_struct.Acceptor
@@ -42,7 +42,7 @@ function UserSpotSelectionV4(spots,PathToMovie,params,A,b,savedir,fps,setnum)
                 end
         end
     end
-%function for putting circles around a spot:
+% function for putting circles around a spot:
     function boxfun(currspot)
         %CalcSpotIntensityV2 puts a circle of diameter 5 around each spot:
         t = 0:pi/100:2*pi;
@@ -50,13 +50,13 @@ function UserSpotSelectionV4(spots,PathToMovie,params,A,b,savedir,fps,setnum)
         clear t
     end
 
-%Make spots 2-by-numspots matrices, if it's not already
+% Make spots 2-by-numspots matrices, if it's not already
 if size(spots,1)~=2
     spots = transpose(spots);
 end
 
 %%%Get all the spot intensities
-%Figure out the total number of image files in this movie:
+% Figure out the total number of image files in this movie:
 alltifs = dir(fullfile(PathToMovie,'img*.tif'));
 allRedI = zeros(size(spots,2),length(alltifs));
 allGrI = zeros(size(spots,2),length(alltifs));
@@ -98,8 +98,8 @@ end
 %%%Interactive section
 k = 1;%Indexes current spot being plotted
 
-%So that when you go back to a previous spot, you don't have to redo
-%selections you did before:
+% So that when you go back to a previous spot, you don't have to redo
+% selections you did before:
 Rbkgnd = zeros(size(spots,2),1);
 Gbkgnd = zeros(size(spots,2),1);
 xlims = zeros(size(spots,2),2);

--- a/smFRET.m
+++ b/smFRET.m
@@ -1,20 +1,20 @@
-%function smFRET
+% function smFRET
 %
-%Wrapper function for analyzing smFRET data--loads data, calls the
-%functions that do the analysis, etc.
+% Wrapper function for analyzing smFRET data--loads data, calls the
+% functions that do the analysis, etc.
 %
-%This will analyze all the movies in a set at once, where a set is defined
-%as having the same root filename with _1, _2 at the end (the way
-%MicroManager saves multiple movies of the same root filename).  They all
-%have to be in the same folder.
+% This will analyze all the movies in a set at once, where a set is defined
+% as having the same root filename with _1, _2 at the end (the way
+% MicroManager saves multiple movies of the same root filename).  They all
+% have to be in the same folder.
 %
-%Inputs are:
-%Root filename (the movies it analyzes will be rootname_1, rootname_2 etc)
-%Optionally: if you want it to run all the various debugging things, pass
-%"1" as the second input.
+% Inputs are:
+% Root filename (the movies it analyzes will be rootname_1, rootname_2 etc)
+% Optionally: if you want it to run all the various debugging things, pass
+% "1" as the second input.
 %
-%Steph 9/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 9/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function smFRET(rootname,debug)
 

--- a/smFRETBoxes.m
+++ b/smFRETBoxes.m
@@ -1,20 +1,20 @@
-%function smFRET
+% function smFRET
 %
-%Wrapper function for analyzing smFRET data--loads data, calls the
-%functions that do the analysis, etc.
+% Wrapper function for analyzing smFRET data--loads data, calls the
+% functions that do the analysis, etc.
 %
-%This will analyze all the movies in a set at once, where a set is defined
-%as having the same root filename with _1, _2 at the end (the way
-%MicroManager saves multiple movies of the same root filename).  They all
-%have to be in the same folder.
+% This will analyze all the movies in a set at once, where a set is defined
+% as having the same root filename with _1, _2 at the end (the way
+% MicroManager saves multiple movies of the same root filename).  They all
+% have to be in the same folder.
 %
-%Inputs are:
-%Root filename (the movies it analyzes will be rootname_1, rootname_2 etc)
-%Optionally: if you want it to run all the various debugging things, pass
-%"1" as the second input.
+% Inputs are:
+% Root filename (the movies it analyzes will be rootname_1, rootname_2 etc)
+% Optionally: if you want it to run all the various debugging things, pass
+% "1" as the second input.
 %
-%Steph 9/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 9/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function smFRETBoxes(rootname,debug)
 

--- a/smFRETsetup.m
+++ b/smFRETsetup.m
@@ -1,43 +1,43 @@
-%function smFRETsetup
+% function smFRETsetup
 %
-%Called by smFRET; sets up some basic parameters. This is the only code 
-%that a new user might have to change.
+% Called by smFRET; sets up some basic parameters. This is the only code 
+% that a new user might have to change.
 %
-%Steph 9/2013
-%Copyright 2013 Stephanie Johnson, University of California, San Francisco
+% Steph 9/2013
+% Copyright 2013 Stephanie Johnson, University of California, San Francisco
 
 function smFRETsetup
 
 %%%%%%%% Directory defaults: %%%%%%%%
-%Where to save analyzed data:
-%defaultsavedir = '/Volumes/smFRET/smFRET data analysis';
+% Where to save analyzed data:
+% defaultsavedir = '/Volumes/smFRET/smFRET data analysis';
 defaultsavedir = '/Users/Steph/Dropbox/Steph Dropbox/Narlikar Lab DB/smFRET data analysis';
-%Where to load data from:
+% Where to load data from:
 defaultdatadir = '/Volumes/smFRET/smFRET data';
-%defaultdatadir = '/Users/Steph/Dropbox/Steph Dropbox/Narlikar Lab DB/smFRET data';
-%Where the code is (which is where it saves this parameter file)
-%codedir = '/Volumes/smFRET/smFRET analysis code';
+% defaultdatadir = '/Users/Steph/Dropbox/Steph Dropbox/Narlikar Lab DB/smFRET data';
+% Where the code is (which is where it saves this parameter file)
+% codedir = '/Volumes/smFRET/smFRET analysis code';
 codedir = '/Users/Steph/Documents/UCSF/Narlikar lab/smFRET analysis code';
 
 %%%%%%%% Display defaults: %%%%%%%
-%These control where the two figures that show traces and a field of view
-%show up on your monitor. Numbers are [top left corner x position, top left y,
-%width, height].  Run figure('Position',Fig2Pos) to see where the figure
-%will show up; adjust the Fig2Pos vector elements as necessary.  Note: Macs
-%and PC's have a different (0,0) for the monitor I think.
-%Fig2Pos = [650,800,700,550];
+% These control where the two figures that show traces and a field of view
+% show up on your monitor. Numbers are [top left corner x position, top left y,
+% width, height].  Run figure('Position',Fig2Pos) to see where the figure
+% will show up; adjust the Fig2Pos vector elements as necessary.  Note: Macs
+% and PC's have a different (0,0) for the monitor I think.
+% Fig2Pos = [650,800,700,550];
 Fig2Pos = [650,800,400,500];
-%Fig1Pos = [0,400,600,500];
+% Fig1Pos = [0,400,600,500];
 Fig1Pos = [0,400,400,500];
 
 %%%%%%%% Microscope-specific parameters: %%%%%%%%
 splitx = 1; %This means red-green channels are left and right (not top and bottom)
 Acceptor = 0; %This means the acceptor channel is the one on the left 
     %(or on the top if splitx is 0)
-%Our acquisition procedure automatically saves other necessary variables
-%like how many pixels on each side our images our, the frame rate, etc.
-%But those could be coded in here and then smFRET rewritten to use values
-%from smFRETsetup rather than from the acquisition file.
+% Our acquisition procedure automatically saves other necessary variables
+% like how many pixels on each side our images our, the frame rate, etc.
+% But those could be coded in here and then smFRET rewritten to use values
+% from smFRETsetup rather than from the acquisition file.
     
 %%%%%%%% Analysis parameters: %%%%%%%%
 FramesToAvg = 10; %How many frames to average over for spotfinding


### PR DESCRIPTION
(duplicate of #3, but after purging the data)

The comments didn't have whitespace after the comment character, so they were hard to read and didn't conform to [Matlab help style](http://www.mathworks.com/help/matlab/matlab_prog/add-help-for-your-program.html) or [Matlab comment style](http://www.mathworks.com/help/matlab/matlab_prog/comments.html) or the style of any language known to man.

I revised them by running this command

``` bash
find . -iname '*.m' -exec gsed -i -E 's/^%([^ \t%])/% \1/' '{}' \;
```

where my gsed points to a version of gnu sed.
